### PR TITLE
Adding some backwards compatibility to mqtt-io

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,7 @@ digital_outputs:
     mqtt_topic_set: "heatpump/output/i1/set"
     mqtt_state_high: "ON"
     mqtt_state_low: "OFF"
+    initial_state: "OFF"
 
 
   # Output to enable PV mode (full steam)

--- a/config.yaml
+++ b/config.yaml
@@ -14,8 +14,8 @@ digital_outputs:
     gpio: 5
     mqtt_topic: "heatpump/output/i1"
     mqtt_topic_set: "heatpump/output/i1/set"
-    mqtt_state_on: "ON"
-    mqtt_state_off: "OFF"
+    mqtt_state_high: "ON"
+    mqtt_state_low: "OFF"
 
 
   # Output to enable PV mode (full steam)

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,10 @@ pub struct MqttConfig {
     pub host: String,
     #[serde(default = "MqttConfig::default_port")]
     pub port: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
     #[serde(default = "MqttConfig::default_qos")]
     pub qos: u8,
     #[serde(default = "MqttConfig::default_keep_alive")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,20 +68,20 @@ pub struct DigitalOutput {
     pub gpio: u32,
     pub mqtt_topic: String,
     pub mqtt_topic_set: String,
-    #[serde(default = "DigitalOutput::default_mqtt_state_on")]
-    pub mqtt_state_on: String,
-    #[serde(default = "DigitalOutput::default_mqtt_state_off")]
-    pub mqtt_state_off: String,
+    #[serde(default = "DigitalOutput::default_mqtt_state_high")]
+    pub mqtt_state_high: String,
+    #[serde(default = "DigitalOutput::default_mqtt_state_low")]
+    pub mqtt_state_low: String,
 }
 
 impl DigitalOutput {
     fn default_name() -> String {
         "gpio".to_string()
     }
-    fn default_mqtt_state_on() -> String {
+    fn default_mqtt_state_high() -> String {
         "ON".to_string()
     }
-    fn default_mqtt_state_off() -> String {
+    fn default_mqtt_state_low() -> String {
         "OFF".to_string()
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,8 @@ pub struct DigitalOutput {
     pub mqtt_state_high: String,
     #[serde(default = "DigitalOutput::default_mqtt_state_low")]
     pub mqtt_state_low: String,
+    #[serde(default = "DigitalOutput::default_initial_state")]
+    pub initial_state: String,
 }
 
 impl DigitalOutput {
@@ -82,6 +84,9 @@ impl DigitalOutput {
         "ON".to_string()
     }
     fn default_mqtt_state_low() -> String {
+        "OFF".to_string()
+    }
+    fn default_initial_state() -> String {
         "OFF".to_string()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ impl<'a> Mqtt<'a> {
         mqtt_options.set_clean_session(self.clean_session);
 
         if self.user.is_some() && self.password.is_some() {
-            mqtt_options.set_credentials(self.user.clone().unwrap(), self.password.clone().unwrap());
+            mqtt_options.set_credentials(self.user.unwrap(), self.password.unwrap());
         }
 
         let (mut client, connection) = Client::new(mqtt_options, self.cap);

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,8 +106,8 @@ struct Pin<'a> {
     // TODO: Infer topics from name and prefix like mqtt-io?
     mqtt_topic: &'a str,
     mqtt_topic_set: &'a str,
-    mqtt_state_on: &'a str,
-    mqtt_state_off: &'a str,
+    mqtt_state_high: &'a str,
+    mqtt_state_low: &'a str,
     qos: QoS,
     retain: bool,
 }
@@ -118,8 +118,8 @@ impl<'a> Pin<'a> {
             line_handle,
             mqtt_topic: "gpio",
             mqtt_topic_set: "gpio/set",
-            mqtt_state_on: "ON",
-            mqtt_state_off: "OFF",
+            mqtt_state_high: "ON",
+            mqtt_state_low: "OFF",
             qos: QoS::AtLeastOnce,
             retain: false,
         }
@@ -129,8 +129,8 @@ impl<'a> Pin<'a> {
         let value = self.line_handle.get_value();
 
         let state = match value {
-            Ok(1) => self.mqtt_state_on,
-            Ok(0) => self.mqtt_state_off,
+            Ok(1) => self.mqtt_state_high,
+            Ok(0) => self.mqtt_state_low,
             _ => panic!("GPIO pin returned neither 0 nor 1, this should never happen!"),
         };
 
@@ -145,12 +145,12 @@ impl<'a> Pin<'a> {
         mqtt_client: &mut Client,
         payload: Bytes,
     ) -> Result<(), gpio_cdev::Error> {
-        if payload == self.mqtt_state_on {
-            println!("Setting {} = {}", self.mqtt_topic, self.mqtt_state_on);
+        if payload == self.mqtt_state_high {
+            println!("Setting {} = {}", self.mqtt_topic, self.mqtt_state_high);
             self.line_handle.set_value(1)?;
             self.publish_state(mqtt_client)?;
-        } else if payload == self.mqtt_state_off {
-            println!("Setting {} = {}", self.mqtt_topic, self.mqtt_state_off);
+        } else if payload == self.mqtt_state_low {
+            println!("Setting {} = {}", self.mqtt_topic, self.mqtt_state_low);
             self.line_handle.set_value(0)?;
             self.publish_state(mqtt_client)?;
         }
@@ -203,6 +203,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         let mut i = Pin::new(handle);
         i.mqtt_topic = &output.mqtt_topic;
         i.mqtt_topic_set = &output.mqtt_topic_set;
+        i.mqtt_state_high = &output.mqtt_state_high;
+        i.mqtt_state_low = &output.mqtt_state_low;
         i.retain = conf.mqtt.retain;
         println!(
             "Registered GPIO pin {} (via {:?})",

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,10 +195,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut pins: Vec<Pin> = Vec::with_capacity(2);
 
     for output in conf.digital_outputs.iter() {
+        let initial_state = if output.initial_state == output.mqtt_state_high { 1 } else { 0 };
+
         // NOTE: OUTPUT lines can also handle get_value() requests
         let handle =
             chip.get_line(output.gpio)?
-                .request(LineRequestFlags::OUTPUT, 0, "write-gpio")?;
+                .request(LineRequestFlags::OUTPUT, initial_state, "write-gpio")?;
 
         let mut i = Pin::new(handle);
         i.mqtt_topic = &output.mqtt_topic;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ mod config;
 struct Mqtt<'a> {
     name: &'a str,
     host: &'a str,
-    user: Option<String>,
-    password: Option<String>,
+    user: Option<&'a str>,
+    password: Option<&'a str>,
     port: u16,
     qos: QoS,
     cap: usize,
@@ -58,7 +58,7 @@ impl<'a> Mqtt<'a> {
     fn connect(&mut self) -> Result<(), ClientError> {
         let mut mqtt_options = MqttOptions::new(self.name, self.host, self.port);
         mqtt_options.set_keep_alive(self.keep_alive);
-        mqtt_options.set_clean_session(self.clean_session); 
+        mqtt_options.set_clean_session(self.clean_session);
 
         if self.user.is_some() && self.password.is_some() {
             mqtt_options.set_credentials(self.user.clone().unwrap(), self.password.clone().unwrap());
@@ -180,8 +180,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let conf: config::Config = serde_yaml::from_reader(reader)?;
 
     let mut mqtt = Mqtt::new(&conf.mqtt.name, &conf.mqtt.host, conf.mqtt.port);
-    mqtt.user = conf.mqtt.user;
-    mqtt.password = conf.mqtt.password;
+    mqtt.user = conf.mqtt.user.as_deref();
+    mqtt.password = conf.mqtt.password.as_deref();
     mqtt.qos = match conf.mqtt.qos {
         0 => QoS::AtMostOnce,
         1 => QoS::AtLeastOnce,

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,8 @@ impl<'a> Mqtt<'a> {
         mqtt_options.set_keep_alive(self.keep_alive);
         mqtt_options.set_clean_session(self.clean_session);
 
-        if self.user.is_some() && self.password.is_some() {
-            mqtt_options.set_credentials(self.user.unwrap(), self.password.unwrap());
+        if let (Some(u), Some(p)) = (self.user, self.password) {
+            mqtt_options.set_credentials(u, p);
         }
 
         let (mut client, connection) = Client::new(mqtt_options, self.cap);


### PR DESCRIPTION
Thanks for building this out in rust!  I had the same issues described in https://github.com/flyte/mqtt-io/issues/282 and decided to try to give your fork a try.  Problem was that I used a bit of the functionality that you hadn't implemented, so I went ahead and implemented them.  I've got it working now for my use-case, and I figure I'd send a pull request so that you could pick up those changes.