### PR TITLE
Implement availability topics

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,12 @@ pub struct MqttConfig {
     pub retain: bool,
     #[serde(default = "MqttConfig::default_cap")]
     pub cap: usize,
+    #[serde(default = "MqttConfig::default_availability_topic")]
+    pub availability_topic: String,
+    #[serde(default = "MqttConfig::default_payload_available")]
+    pub payload_available: String,
+    #[serde(default = "MqttConfig::default_payload_not_available")]
+    pub payload_not_available: String,
 }
 
 impl MqttConfig {
@@ -62,6 +68,15 @@ impl MqttConfig {
     }
     fn default_cap() -> usize {
         10
+    }
+    fn default_availability_topic() -> String {
+        "rpi-mqtt-gpio/status".to_string()
+    }
+    fn default_payload_available() -> String {
+        "online".to_string()
+    }
+    fn default_payload_not_available() -> String {
+        "offline".to_string()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ impl<'a> Mqtt<'a> {
             keep_alive: Duration::from_secs(5),
             cap: 10,
             clean_session: false,
-            availability_topic: "gpio/availability",
+            availability_topic: "rpi-mqtt-gpio/status",
             payload_available: "online",
             payload_not_available: "offline",
             subscribe: vec!["#"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use gpio_cdev::{Chip, LineHandle, LineRequestFlags};
-use rumqttc::{Client, ClientError, Connection, Event, MqttOptions, Packet, QoS, SubscribeFilter};
-use rumqttc::mqttbytes::v4::LastWill;
+use rumqttc::{Client, ClientError, Connection, Event, LastWill, MqttOptions, Packet, QoS, SubscribeFilter};
 
 mod config;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ impl<'a> Mqtt<'a> {
             mqtt_options.set_credentials(self.user.unwrap(), self.password.unwrap());
         }
 
-        mqtt_options.set_last_will(LastWill::new(self.availability_topic, self.payload_not_available, self.qos, false));
+        mqtt_options.set_last_will(LastWill::new(self.availability_topic, self.payload_not_available, self.qos, true));
 
         let (mut client, connection) = Client::new(mqtt_options, self.cap);
 
@@ -84,7 +84,7 @@ impl<'a> Mqtt<'a> {
 
         println!("Setting {} = {}", self.availability_topic, self.payload_available);
         client
-            .publish(self.availability_topic, self.qos, false, self.payload_available)
+            .publish(self.availability_topic, self.qos, true, self.payload_available)
             .unwrap_or_else(|e| println!("Error publishing: {e}"));
 
         self.mqtt_client.client = Some(client);


### PR DESCRIPTION
An availability topic is useful to notify consumers on whether the switch is available or not based on whether the daemon is running. In particular, home assistant (https://www.home-assistant.io/integrations/switch.mqtt/#availability) uses this to show an unavailable state in case the daemon is not running.