### PR TITLE
Send availability message on reconnect

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use bytes::Bytes;
 use gpio_cdev::{Chip, LineHandle, LineRequestFlags};
 use rumqttc::{
-    Client, ClientError, ConnAck, Connection, Event, LastWill, MqttOptions, Packet, QoS,
-    SubscribeFilter,
+    Client, ClientError, ConnAck, ConnectReturnCode, Connection, Event, LastWill, MqttOptions,
+    Packet, QoS, SubscribeFilter,
 };
 
 mod config;
@@ -122,7 +122,7 @@ impl<'a> Mqtt<'a> {
                 }
                 Ok(Event::Incoming(Packet::ConnAck(ConnAck {
                     session_present: true,
-                    code: rumqttc::ConnectReturnCode::Success,
+                    code: ConnectReturnCode::Success,
                 }))) => {
                     // Send available message on connect/reconnect
                     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,7 @@ impl<'a> Mqtt<'a> {
                         )
                         .unwrap_or_else(|e| println!("Error publishing: {e}"));
                 }
+                // Ignore all other incoming messages
                 _ => (),
             };
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,6 @@ impl<'a> Mqtt<'a> {
                     for p in pins.iter() {
                         if n.topic == p.mqtt_topic_set {
                             p.set_and_publish_state(client, n.payload.to_owned())?;
-                            continue;
                         }
                     }
                 }


### PR DESCRIPTION
I missed one of the cases in which the availability topic needed to be updated: the case in which the mqtt broker dies or is restarted.  In that case, the LWT message stating that the daemon is dead is triggered, and as a result, home assistant sees the switch as unavailable.  However, when the daemon reconnects, which it does automatically, it currently does not send a message that its back online, so home assistant continues to think it is dead even though it is healthy.

It took some digging, but I was able to figure out that in the event loop we can listen for the connect message and send the online message there.  We no longer need to send it on initial connection setup as both the initial connection and re-connections will trigger that event loop notification.

I tested this by killing and restarting my broker several times, and home assistant always shows the correct available/unavailable state.  Also tested by starting and stopping the daemon produced the expected states, but that was also happening prior to this PR.